### PR TITLE
Integrate management modals and templates

### DIFF
--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -1,13 +1,17 @@
 const sequelize = require('../config/db');
 const Usuario = require('./usuario.model');
 const Gestion = require('./gestion.model');
+const Plantilla = require('./plantilla.model');
+const UsuarioGestion = require('./usuarioGestion.model');
 
 // Relaciones
-Gestion.hasMany(Usuario, { foreignKey: 'gestionId' });
-Usuario.belongsTo(Gestion, { foreignKey: 'gestionId' });
+Usuario.belongsToMany(Gestion, { through: UsuarioGestion, foreignKey: 'usuarioId' });
+Gestion.belongsToMany(Usuario, { through: UsuarioGestion, foreignKey: 'gestionId' });
 
 module.exports = {
   sequelize,
   Usuario,
-  Gestion
+  Gestion,
+  Plantilla,
+  UsuarioGestion
 };

--- a/backend/models/plantilla.model.js
+++ b/backend/models/plantilla.model.js
@@ -1,112 +1,17 @@
-// models/plantilla.model.js
 const { DataTypes } = require('sequelize');
 const sequelize = require('../config/db');
 
 const Plantilla = sequelize.define('Plantilla', {
-  titulo: {
-    type: DataTypes.STRING,
-    allowNull: false
-  },
-  mensaje: {
+  texto: {
     type: DataTypes.TEXT,
     allowNull: false
   },
-  icono: {
-    type: DataTypes.STRING,
-    allowNull: true
-  },
-  creadoPor: {
-    type: DataTypes.INTEGER,
-    allowNull: false
+  visible: {
+    type: DataTypes.BOOLEAN,
+    defaultValue: true
   }
 }, {
   tableName: 'Plantillas'
 });
 
 module.exports = Plantilla;
-
-
-// middleware/auth.middleware.js
-const jwt = require('jsonwebtoken');
-const { JWT_SECRET } = process.env;
-
-function verificarToken(req, res, next) {
-  const auth = req.headers.authorization;
-  if (!auth) return res.status(401).json({ error: 'Token requerido' });
-
-  const token = auth.split(' ')[1];
-  try {
-    const payload = jwt.verify(token, JWT_SECRET);
-    req.user = payload;
-    next();
-  } catch (err) {
-    return res.status(403).json({ error: 'Token inválido' });
-  }
-}
-
-function soloRoles(...roles) {
-  return (req, res, next) => {
-    if (!roles.includes(req.user.rol)) {
-      return res.status(403).json({ error: 'No autorizado' });
-    }
-    next();
-  };
-}
-
-module.exports = { verificarToken, soloRoles };
-
-
-// routes/plantilla.routes.js
-const express = require('express');
-const router = express.Router();
-const Plantilla = require('../models/plantilla.model');
-const { verificarToken, soloRoles } = require('../middleware/auth.middleware');
-
-// Crear plantilla (supervisor)
-router.post('/', verificarToken, soloRoles('supervisor'), async (req, res) => {
-  try {
-    const { titulo, mensaje, icono } = req.body;
-    const plantilla = await Plantilla.create({
-      titulo,
-      mensaje,
-      icono,
-      creadoPor: req.user.id
-    });
-    res.status(201).json(plantilla);
-  } catch (err) {
-    res.status(500).json({ error: 'Error al crear plantilla' });
-  }
-});
-
-// Obtener todas (agentes y supervisores)
-router.get('/', verificarToken, async (req, res) => {
-  try {
-    const plantillas = await Plantilla.findAll();
-    res.json(plantillas);
-  } catch (err) {
-    res.status(500).json({ error: 'Error al obtener plantillas' });
-  }
-});
-
-// Eliminar plantilla (supervisor)
-router.delete('/:id', verificarToken, soloRoles('supervisor'), async (req, res) => {
-  try {
-    await Plantilla.destroy({ where: { id: req.params.id } });
-    res.json({ message: 'Eliminado' });
-  } catch (err) {
-    res.status(500).json({ error: 'Error al eliminar' });
-  }
-});
-
-// Actualizar plantilla (supervisor)
-router.put('/:id', verificarToken, soloRoles('supervisor'), async (req, res) => {
-  try {
-    const { titulo, mensaje, icono } = req.body;
-    await Plantilla.update({ titulo, mensaje, icono }, { where: { id: req.params.id } });
-    res.json({ message: 'Actualizado' });
-  } catch (err) {
-    res.status(500).json({ error: 'Error al actualizar' });
-  }
-});
-
-module.exports = router;

--- a/backend/models/usuarioGestion.model.js
+++ b/backend/models/usuarioGestion.model.js
@@ -1,0 +1,8 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../config/db');
+
+const UsuarioGestion = sequelize.define('UsuarioGestion', {}, {
+  tableName: 'UsuarioGestiones'
+});
+
+module.exports = UsuarioGestion;

--- a/backend/routes/gestion.routes.js
+++ b/backend/routes/gestion.routes.js
@@ -1,34 +1,39 @@
-// routes/gestion.routes.js
 const express = require('express');
 const router = express.Router();
-const { Gestion } = require('../models/gestion.model');
+const { Gestion } = require('../models');
+const auth = require('../middlewares/auth.middleware');
+
+router.use(auth);
 
 router.get('/', async (req, res) => {
   try {
     const gestiones = await Gestion.findAll({ attributes: ['id', 'nombre'] });
     res.json(gestiones);
   } catch (err) {
-    console.error('Error al listar gestiones:', err);
     res.status(500).json({ mensaje: 'Error al obtener gestiones' });
   }
 });
-// routes/gestion.routes.js
+
 router.post('/', async (req, res) => {
-  const { nombre } = req.body;
-  const nueva = await Gestion.create({ nombre });
-  res.status(201).json(nueva);
+  if (req.usuario.rol !== 'sistema') return res.status(403).json({ mensaje: 'No autorizado' });
+  try {
+    const { nombre } = req.body;
+    const nueva = await Gestion.create({ nombre });
+    res.status(201).json(nueva);
+  } catch (err) {
+    res.status(500).json({ mensaje: 'Error al crear gestion' });
+  }
 });
 
 router.put('/:id', async (req, res) => {
-  const { nombre } = req.body;
-  await Gestion.update({ nombre }, { where: { id: req.params.id } });
-  res.json({ mensaje: 'Actualizado' });
+  if (req.usuario.rol !== 'sistema') return res.status(403).json({ mensaje: 'No autorizado' });
+  try {
+    const { nombre } = req.body;
+    await Gestion.update({ nombre }, { where: { id: req.params.id } });
+    res.json({ mensaje: 'Actualizado' });
+  } catch (err) {
+    res.status(500).json({ mensaje: 'Error al actualizar' });
+  }
 });
-
-router.delete('/:id', async (req, res) => {
-  await Gestion.destroy({ where: { id: req.params.id } });
-  res.json({ mensaje: 'Eliminado' });
-});
-
 
 module.exports = router;

--- a/backend/routes/plantilla.routes.js
+++ b/backend/routes/plantilla.routes.js
@@ -1,0 +1,41 @@
+const express = require('express');
+const router = express.Router();
+const { Plantilla } = require('../models');
+const auth = require('../middlewares/auth.middleware');
+
+router.use(auth);
+
+router.get('/', async (req, res) => {
+  try {
+    const plantillas = await Plantilla.findAll();
+    res.json(plantillas);
+  } catch (err) {
+    res.status(500).json({ mensaje: 'Error al obtener plantillas' });
+  }
+});
+
+router.post('/', async (req, res) => {
+  if (req.usuario.rol !== 'sistema') return res.status(403).json({ mensaje: 'No autorizado' });
+  try {
+    const { texto } = req.body;
+    const nueva = await Plantilla.create({ texto, visible: true });
+    res.status(201).json(nueva);
+  } catch (err) {
+    res.status(500).json({ mensaje: 'Error al crear plantilla' });
+  }
+});
+
+router.put('/:id/visible', async (req, res) => {
+  if (req.usuario.rol !== 'sistema') return res.status(403).json({ mensaje: 'No autorizado' });
+  try {
+    const plantilla = await Plantilla.findByPk(req.params.id);
+    if (!plantilla) return res.status(404).json({ mensaje: 'No encontrada' });
+    plantilla.visible = req.body.visible;
+    await plantilla.save();
+    res.json(plantilla);
+  } catch (err) {
+    res.status(500).json({ mensaje: 'Error al actualizar' });
+  }
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -4,7 +4,9 @@ const cors = require('cors');
 const sequelize = require('./config/db');
 
 const authRoutes = require('./routes/auth.routes');
-const usuarioRoutes = require('./routes/usuario.routes'); // ✅ NUEVO
+const usuarioRoutes = require('./routes/usuario.routes');
+const gestionRoutes = require('./routes/gestion.routes');
+const plantillaRoutes = require('./routes/plantilla.routes');
 
 const app = express();
 app.use(cors());
@@ -12,7 +14,9 @@ app.use(express.json());
 
 // Rutas principales
 app.use('/api/auth', authRoutes);
-app.use('/api/usuarios', usuarioRoutes); // ✅ NUEVO
+app.use('/api/usuarios', usuarioRoutes);
+app.use('/api/gestiones', gestionRoutes);
+app.use('/api/plantillas', plantillaRoutes);
 
 const PORT = process.env.PORT || 3000;
 
@@ -24,6 +28,3 @@ sequelize.sync().then(() => {
 }).catch(err => {
   console.error('❌ Error al conectar:', err);
 });
-
-const gestionRoutes = require('./routes/gestion.routes');
-app.use('/api/gestiones', gestionRoutes);

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -10,8 +10,17 @@ const Dashboard = () => {
   const [error, setError] = useState(null);
   const [gestiones, setGestiones] = useState([]);
   const [gestionesSeleccionadas, setGestionesSeleccionadas] = useState([]);
+  const [mostrarNuevo, setMostrarNuevo] = useState(false);
+  const [mostrarGestiones, setMostrarGestiones] = useState(false);
+  const [mostrarPlantillas, setMostrarPlantillas] = useState(false);
+  const [formUsuario, setFormUsuario] = useState({ username: '', nombre: '', apellido: '', rol: 'agente', password: '' });
+  const [nuevaGestion, setNuevaGestion] = useState('');
+  const [plantillas, setPlantillas] = useState([]);
+  const [nuevaPlantilla, setNuevaPlantilla] = useState('');
 
   const token = localStorage.getItem('token');
+  const usuario = JSON.parse(localStorage.getItem('usuario') || '{}');
+  const esSistema = usuario.rol === 'sistema';
 
   const cargarUsuarios = async () => {
     try {
@@ -37,6 +46,61 @@ const Dashboard = () => {
     }
   };
 
+  const cargarPlantillas = async () => {
+    try {
+      const res = await axios.get('http://localhost:3000/api/plantillas', {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      setPlantillas(res.data);
+    } catch (err) {
+      console.error('Error al cargar plantillas:', err);
+    }
+  };
+
+  const crearUsuario = async () => {
+    try {
+      await axios.post('http://localhost:3000/api/usuarios', {
+        ...formUsuario,
+        gestiones: gestionesSeleccionadas.map(g => g.value)
+      }, { headers: { Authorization: `Bearer ${token}` } });
+      setFormUsuario({ username: '', nombre: '', apellido: '', rol: 'agente', password: '' });
+      setGestionesSeleccionadas([]);
+      setMostrarNuevo(false);
+      cargarUsuarios();
+    } catch (err) {
+      console.error('Error al crear usuario:', err);
+    }
+  };
+
+  const agregarGestion = async () => {
+    try {
+      await axios.post('http://localhost:3000/api/gestiones', { nombre: nuevaGestion }, { headers: { Authorization: `Bearer ${token}` } });
+      setNuevaGestion('');
+      cargarGestiones();
+    } catch (err) {
+      console.error('Error al crear gestion:', err);
+    }
+  };
+
+  const agregarPlantilla = async () => {
+    try {
+      await axios.post('http://localhost:3000/api/plantillas', { texto: nuevaPlantilla }, { headers: { Authorization: `Bearer ${token}` } });
+      setNuevaPlantilla('');
+      cargarPlantillas();
+    } catch (err) {
+      console.error('Error al crear plantilla:', err);
+    }
+  };
+
+  const cambiarVisibilidad = async (id, visible) => {
+    try {
+      await axios.put(`http://localhost:3000/api/plantillas/${id}/visible`, { visible }, { headers: { Authorization: `Bearer ${token}` } });
+      cargarPlantillas();
+    } catch (err) {
+      console.error('Error al actualizar plantilla:', err);
+    }
+  };
+
   const cambiarEstado = async (id) => {
     try {
       await axios.patch(`http://localhost:3000/api/usuarios/${id}/estado`, {}, {
@@ -52,6 +116,7 @@ const Dashboard = () => {
   useEffect(() => {
     cargarUsuarios();
     cargarGestiones();
+    cargarPlantillas();
   }, []);
 
   return (
@@ -60,6 +125,16 @@ const Dashboard = () => {
       <p className="mb-6">Listado de usuarios registrados</p>
 
       {error && <p className="text-red-600 mb-4">{error}</p>}
+
+      <div className="flex gap-4 mb-4">
+        <button onClick={() => setMostrarNuevo(true)} className="bg-blue-600 text-white px-4 py-2 rounded">Nuevo usuario</button>
+        {esSistema && (
+          <>
+            <button onClick={() => setMostrarGestiones(true)} className="bg-green-600 text-white px-4 py-2 rounded">Administrar gestiones</button>
+            <button onClick={() => setMostrarPlantillas(true)} className="bg-purple-600 text-white px-4 py-2 rounded">Gestión de plantillas</button>
+          </>
+        )}
+      </div>
 
       <div className="mb-6">
         <label className="block mb-2 font-semibold">Gestiones (multi-selección):</label>
@@ -91,7 +166,7 @@ const Dashboard = () => {
               <td className="py-2 px-4">{u.nombre}</td>
               <td className="py-2 px-4">{u.apellido}</td>
               <td className="py-2 px-4 capitalize">{u.rol}</td>
-              <td className="py-2 px-4">{u.gestionId || '—'}</td>
+              <td className="py-2 px-4">{u.Gestions?.map(g => g.nombre).join(', ') || '—'}</td>
               <td className="py-2 px-4">
                 <button
                   className={`px-2 py-1 rounded text-white ${u.estado === 'activo' ? 'bg-green-600' : 'bg-gray-500'}`}
@@ -107,6 +182,71 @@ const Dashboard = () => {
           ))}
         </tbody>
       </table>
+
+      {mostrarNuevo && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+          <div className="bg-white p-6 rounded w-96">
+            <h2 className="text-xl font-bold mb-4">Nuevo usuario</h2>
+            <input className="border p-2 w-full mb-2" placeholder="Usuario" value={formUsuario.username} onChange={e => setFormUsuario({ ...formUsuario, username: e.target.value })} />
+            <input className="border p-2 w-full mb-2" placeholder="Nombre" value={formUsuario.nombre} onChange={e => setFormUsuario({ ...formUsuario, nombre: e.target.value })} />
+            <input className="border p-2 w-full mb-2" placeholder="Apellido" value={formUsuario.apellido} onChange={e => setFormUsuario({ ...formUsuario, apellido: e.target.value })} />
+            <select className="border p-2 w-full mb-2" value={formUsuario.rol} onChange={e => setFormUsuario({ ...formUsuario, rol: e.target.value })}>
+              <option value="sistema">Sistema</option>
+              <option value="supervisor">Supervisor</option>
+              <option value="agente">Agente</option>
+            </select>
+            <input type="password" className="border p-2 w-full mb-2" placeholder="Contraseña" value={formUsuario.password} onChange={e => setFormUsuario({ ...formUsuario, password: e.target.value })} />
+            <Select components={animatedComponents} isMulti options={gestiones} value={gestionesSeleccionadas} onChange={setGestionesSeleccionadas} className="mb-4" />
+            <div className="flex justify-end gap-2">
+              <button onClick={() => setMostrarNuevo(false)} className="px-4 py-2">Cancelar</button>
+              <button onClick={crearUsuario} className="bg-blue-600 text-white px-4 py-2 rounded">Guardar</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {mostrarGestiones && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+          <div className="bg-white p-6 rounded w-80">
+            <h2 className="text-xl font-bold mb-4">Gestiones</h2>
+            <div className="flex mb-4">
+              <input className="border p-2 flex-1" placeholder="Nueva gestion" value={nuevaGestion} onChange={e => setNuevaGestion(e.target.value)} />
+              <button onClick={agregarGestion} className="bg-green-600 text-white px-4 ml-2">Agregar</button>
+            </div>
+            <ul className="max-h-40 overflow-y-auto mb-4">
+              {gestiones.map(g => (
+                <li key={g.value} className="border-b py-1">{g.label}</li>
+              ))}
+            </ul>
+            <div className="text-right">
+              <button onClick={() => setMostrarGestiones(false)} className="px-4 py-2 bg-gray-200 rounded">Cerrar</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {mostrarPlantillas && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+          <div className="bg-white p-6 rounded w-96">
+            <h2 className="text-xl font-bold mb-4">Plantillas</h2>
+            <textarea className="border p-2 w-full mb-2" rows="3" placeholder="Texto de la plantilla" value={nuevaPlantilla} onChange={e => setNuevaPlantilla(e.target.value)} />
+            <div className="flex justify-end mb-4">
+              <button onClick={agregarPlantilla} className="bg-purple-600 text-white px-4 py-2 rounded">Guardar</button>
+            </div>
+            <ul className="max-h-40 overflow-y-auto">
+              {plantillas.map(p => (
+                <li key={p.id} className="border-b py-1 flex justify-between items-center">
+                  <span className="mr-2 flex-1">{p.texto}</span>
+                  <button onClick={() => cambiarVisibilidad(p.id, !p.visible)} className="text-sm text-blue-600">{p.visible ? 'Ocultar' : 'Mostrar'}</button>
+                </li>
+              ))}
+            </ul>
+            <div className="text-right mt-2">
+              <button onClick={() => setMostrarPlantillas(false)} className="px-4 py-2 bg-gray-200 rounded">Cerrar</button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -12,6 +12,7 @@ export default function Login() {
     try {
       const res = await axios.post('http://localhost:3000/api/auth/login', { username, password });
       localStorage.setItem('token', res.data.token);
+      localStorage.setItem('usuario', JSON.stringify(res.data.user));
       navigate('/dashboard');
     } catch (err) {
       alert('Credenciales incorrectas');


### PR DESCRIPTION
## Summary
- support many-to-many Gestiones per usuario
- add Plantilla model and routes
- expose new gestion and plantilla routes in server
- update usuario controller with gestiones and hashing
- store user info on login
- extend dashboard with modals to manage usuarios, gestiones and plantillas

## Testing
- `node node_modules/vite/bin/vite.js build`

------
https://chatgpt.com/codex/tasks/task_e_6860908752488327a74f064b7bf02db9