### PR TITLE
Fix role middleware usage

### DIFF
--- a/backend/middlewares/role.middleware.js
+++ b/backend/middlewares/role.middleware.js
@@ -1,7 +1,7 @@
 module.exports = function (...rolesPermitidos) {
   return (req, res, next) => {
     try {
-      if (!req.user || !rolesPermitidos.includes(req.user.rol)) {
+      if (!req.usuario || !rolesPermitidos.includes(req.usuario.rol)) {
         return res.status(403).json({ error: 'Acceso denegado' });
       }
       next();

--- a/backend/routes/usuario.routes.js
+++ b/backend/routes/usuario.routes.js
@@ -3,15 +3,16 @@ const express = require('express');
 const router = express.Router();
 const usuarioController = require('../controllers/usuario.controller');
 const authMiddleware = require('../middlewares/auth.middleware'); // ✅ Debe existir este archivo y ser una función
+const roleMiddleware = require('../middlewares/role.middleware');
 
 // Middleware para proteger las rutas
 router.use(authMiddleware);
 
 // Rutas
 router.get('/', usuarioController.listarUsuarios);
-router.post('/', usuarioController.crearUsuario);
-router.put('/:id', usuarioController.actualizarUsuario);
-router.patch('/:id/estado', usuarioController.cambiarEstadoUsuario);
+router.post('/', roleMiddleware('sistema'), usuarioController.crearUsuario);
+router.put('/:id', roleMiddleware('sistema'), usuarioController.actualizarUsuario);
+router.patch('/:id/estado', roleMiddleware('sistema'), usuarioController.cambiarEstadoUsuario);
 
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- fix role middleware to check `req.usuario.rol`
- restrict usuario management routes using role middleware

## Testing
- `node -e "const r=require('./backend/middlewares/role.middleware'); console.log(typeof r('sistema'));"`
- `node -e "require('./backend/routes/usuario.routes')"`


------
https://chatgpt.com/codex/tasks/task_e_6860b109bdb48327a8dc26a57c771a7a