### PR TITLE
Use shared axios instance with relative URLs

### DIFF
--- a/frontend/src/api/axios.js
+++ b/frontend/src/api/axios.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const instance = axios.create({
-  baseURL: 'http://localhost:3000/api',
+  baseURL: '/api',
 });
 
 instance.interceptors.request.use(

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -24,7 +24,7 @@ const Dashboard = () => {
 
   const cargarUsuarios = async () => {
     try {
-      const res = await axios.get('http://localhost:3000/api/usuarios', {
+      const res = await axios.get('/usuarios', {
         headers: { Authorization: `Bearer ${token}` }
       });
       setUsuarios(res.data);
@@ -36,7 +36,7 @@ const Dashboard = () => {
 
   const cargarGestiones = async () => {
     try {
-      const res = await axios.get('http://localhost:3000/api/gestiones', {
+      const res = await axios.get('/gestiones', {
         headers: { Authorization: `Bearer ${token}` }
       });
       setGestiones(res.data.map(g => ({ value: g.id, label: g.nombre })));
@@ -48,7 +48,7 @@ const Dashboard = () => {
 
   const cargarPlantillas = async () => {
     try {
-      const res = await axios.get('http://localhost:3000/api/plantillas', {
+      const res = await axios.get('/plantillas', {
         headers: { Authorization: `Bearer ${token}` }
       });
       setPlantillas(res.data);
@@ -59,7 +59,7 @@ const Dashboard = () => {
 
   const crearUsuario = async () => {
     try {
-      await axios.post('http://localhost:3000/api/usuarios', {
+      await axios.post('/usuarios', {
         ...formUsuario,
         gestiones: gestionesSeleccionadas.map(g => g.value)
       }, { headers: { Authorization: `Bearer ${token}` } });
@@ -74,7 +74,7 @@ const Dashboard = () => {
 
   const agregarGestion = async () => {
     try {
-      await axios.post('http://localhost:3000/api/gestiones', { nombre: nuevaGestion }, { headers: { Authorization: `Bearer ${token}` } });
+      await axios.post('/gestiones', { nombre: nuevaGestion }, { headers: { Authorization: `Bearer ${token}` } });
       setNuevaGestion('');
       cargarGestiones();
     } catch (err) {
@@ -84,7 +84,7 @@ const Dashboard = () => {
 
   const agregarPlantilla = async () => {
     try {
-      await axios.post('http://localhost:3000/api/plantillas', { texto: nuevaPlantilla }, { headers: { Authorization: `Bearer ${token}` } });
+      await axios.post('/plantillas', { texto: nuevaPlantilla }, { headers: { Authorization: `Bearer ${token}` } });
       setNuevaPlantilla('');
       cargarPlantillas();
     } catch (err) {
@@ -94,7 +94,7 @@ const Dashboard = () => {
 
   const cambiarVisibilidad = async (id, visible) => {
     try {
-      await axios.put(`http://localhost:3000/api/plantillas/${id}/visible`, { visible }, { headers: { Authorization: `Bearer ${token}` } });
+      await axios.put(`/plantillas/${id}/visible`, { visible }, { headers: { Authorization: `Bearer ${token}` } });
       cargarPlantillas();
     } catch (err) {
       console.error('Error al actualizar plantilla:', err);
@@ -103,7 +103,7 @@ const Dashboard = () => {
 
   const cambiarEstado = async (id) => {
     try {
-      await axios.patch(`http://localhost:3000/api/usuarios/${id}/estado`, {}, {
+      await axios.patch(`/usuarios/${id}/estado`, {}, {
         headers: { Authorization: `Bearer ${token}` }
       });
       cargarUsuarios();

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import axios from 'axios';
+import axios from '../api/axios';
 import { useNavigate } from 'react-router-dom';
 
 export default function Login() {
@@ -10,7 +10,7 @@ export default function Login() {
   const handleLogin = async (e) => {
     e.preventDefault();
     try {
-      const res = await axios.post('http://localhost:3000/api/auth/login', { username, password });
+      const res = await axios.post('/auth/login', { username, password });
       localStorage.setItem('token', res.data.token);
       localStorage.setItem('usuario', JSON.stringify(res.data.user));
       navigate('/dashboard');

--- a/frontend/src/pages/Usuarios.jsx
+++ b/frontend/src/pages/Usuarios.jsx
@@ -1,6 +1,6 @@
 // frontend/src/pages/Usuarios.jsx
 import { useEffect, useState } from 'react';
-import axios from 'axios';
+import axios from '../api/axios';
 
 function Usuarios() {
   const [usuarios, setUsuarios] = useState([]);
@@ -17,7 +17,7 @@ function Usuarios() {
 
   const cargarUsuarios = async () => {
     try {
-      const res = await axios.get('http://localhost:3000/api/usuarios', {
+      const res = await axios.get('/usuarios', {
         headers: { Authorization: `Bearer ${token}` }
       });
       setUsuarios(res.data);
@@ -29,11 +29,11 @@ function Usuarios() {
   const guardarUsuario = async () => {
     try {
       if (editando) {
-        await axios.put(`http://localhost:3000/api/usuarios/${editando}`, formulario, {
+        await axios.put(`/usuarios/${editando}`, formulario, {
           headers: { Authorization: `Bearer ${token}` }
         });
       } else {
-        await axios.post('http://localhost:3000/api/usuarios', formulario, {
+        await axios.post('/usuarios', formulario, {
           headers: { Authorization: `Bearer ${token}` }
         });
       }
@@ -47,7 +47,7 @@ function Usuarios() {
 
   const cambiarEstado = async (id) => {
     try {
-      await axios.patch(`http://localhost:3000/api/usuarios/${id}/estado`, {}, {
+      await axios.patch(`/usuarios/${id}/estado`, {}, {
         headers: { Authorization: `Bearer ${token}` }
       });
       cargarUsuarios();


### PR DESCRIPTION
## Summary
- point axios base URL at `/api`
- use relative paths for API requests
- import axios instance from `../api/axios`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6860b44796688327943de3724d8354d1