### PR TITLE
Update role middleware to check req.usuario

### DIFF
--- a/backend/controllers/plantilla.controller.js
+++ b/backend/controllers/plantilla.controller.js
@@ -4,7 +4,7 @@ const { Plantilla } = require('../models');
 exports.crearPlantilla = async (req, res) => {
   try {
     const { titulo, contenido, icono } = req.body;
-    const { id: usuarioId, rol } = req.user;
+    const { id: usuarioId, rol } = req.usuario;
 
     if (rol !== 'supervisor') return res.status(403).json({ error: 'Solo supervisores pueden crear plantillas' });
 
@@ -29,7 +29,7 @@ exports.obtenerPlantillas = async (req, res) => {
 exports.eliminarPlantilla = async (req, res) => {
   try {
     const { id } = req.params;
-    const { rol, id: userId } = req.user;
+    const { rol, id: userId } = req.usuario;
 
     const plantilla = await Plantilla.findByPk(id);
     if (!plantilla) return res.status(404).json({ error: 'Plantilla no encontrada' });

--- a/backend/middlewares/role.middleware.js
+++ b/backend/middlewares/role.middleware.js
@@ -1,7 +1,8 @@
-module.exports = function (...rolesPermitidos) {
+function roleMiddleware(...rolesPermitidos) {
   return (req, res, next) => {
     try {
-      if (!req.usuario || !rolesPermitidos.includes(req.usuario.rol)) {
+      const { usuario } = req;
+      if (!usuario || !rolesPermitidos.includes(usuario.rol)) {
         return res.status(403).json({ error: 'Acceso denegado' });
       }
       next();
@@ -10,4 +11,6 @@ module.exports = function (...rolesPermitidos) {
       return res.status(500).json({ error: 'Error interno' });
     }
   };
-};
+}
+
+module.exports = roleMiddleware;

--- a/backend/routes/gestion.routes.js
+++ b/backend/routes/gestion.routes.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router = express.Router();
 const { Gestion } = require('../models');
 const auth = require('../middlewares/auth.middleware');
+const roleMiddleware = require('../middlewares/role.middleware');
 
 router.use(auth);
 
@@ -14,8 +15,7 @@ router.get('/', async (req, res) => {
   }
 });
 
-router.post('/', async (req, res) => {
-  if (req.usuario.rol !== 'sistema') return res.status(403).json({ mensaje: 'No autorizado' });
+router.post('/', roleMiddleware('sistema'), async (req, res) => {
   try {
     const { nombre } = req.body;
     const nueva = await Gestion.create({ nombre });
@@ -25,8 +25,7 @@ router.post('/', async (req, res) => {
   }
 });
 
-router.put('/:id', async (req, res) => {
-  if (req.usuario.rol !== 'sistema') return res.status(403).json({ mensaje: 'No autorizado' });
+router.put('/:id', roleMiddleware('sistema'), async (req, res) => {
   try {
     const { nombre } = req.body;
     await Gestion.update({ nombre }, { where: { id: req.params.id } });

--- a/backend/routes/plantilla.routes.js
+++ b/backend/routes/plantilla.routes.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router = express.Router();
 const { Plantilla } = require('../models');
 const auth = require('../middlewares/auth.middleware');
+const roleMiddleware = require('../middlewares/role.middleware');
 
 router.use(auth);
 
@@ -14,8 +15,7 @@ router.get('/', async (req, res) => {
   }
 });
 
-router.post('/', async (req, res) => {
-  if (req.usuario.rol !== 'sistema') return res.status(403).json({ mensaje: 'No autorizado' });
+router.post('/', roleMiddleware('sistema'), async (req, res) => {
   try {
     const { texto } = req.body;
     const nueva = await Plantilla.create({ texto, visible: true });
@@ -25,8 +25,7 @@ router.post('/', async (req, res) => {
   }
 });
 
-router.put('/:id/visible', async (req, res) => {
-  if (req.usuario.rol !== 'sistema') return res.status(403).json({ mensaje: 'No autorizado' });
+router.put('/:id/visible', roleMiddleware('sistema'), async (req, res) => {
   try {
     const plantilla = await Plantilla.findByPk(req.params.id);
     if (!plantilla) return res.status(404).json({ mensaje: 'No encontrada' });

--- a/backend/routes/user.routes.js
+++ b/backend/routes/user.routes.js
@@ -5,7 +5,7 @@ const verifyToken = require('../middlewares/auth.middleware');
 router.get('/me', verifyToken, (req, res) => {
   res.json({
     message: 'Token válido',
-    user: req.user
+    user: req.usuario
   });
 });
 


### PR DESCRIPTION
## Summary
- export role middleware function that checks `req.usuario`
- rely on the middleware in routes for Gestiones and Plantillas
- use `req.usuario` in user-related routes and controllers

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6860b56ff93083279f25c4c26693494b