### PR TITLE
Add gestion linkage to Plantilla model and routes

### DIFF
--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -7,6 +7,8 @@ const UsuarioGestion = require('./usuarioGestion.model');
 // Relaciones
 Usuario.belongsToMany(Gestion, { through: UsuarioGestion, foreignKey: 'usuarioId' });
 Gestion.belongsToMany(Usuario, { through: UsuarioGestion, foreignKey: 'gestionId' });
+Gestion.hasMany(Plantilla, { foreignKey: 'gestionId' });
+Plantilla.belongsTo(Gestion, { foreignKey: 'gestionId' });
 
 module.exports = {
   sequelize,

--- a/backend/models/plantilla.model.js
+++ b/backend/models/plantilla.model.js
@@ -6,6 +6,14 @@ const Plantilla = sequelize.define('Plantilla', {
     type: DataTypes.TEXT,
     allowNull: false
   },
+  gestionId: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+    references: {
+      model: 'Gestiones',
+      key: 'id'
+    }
+  },
   visible: {
     type: DataTypes.BOOLEAN,
     defaultValue: true

--- a/backend/routes/plantilla.routes.js
+++ b/backend/routes/plantilla.routes.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const router = express.Router();
-const { Plantilla } = require('../models');
+const { Plantilla, UsuarioGestion } = require('../models');
 const auth = require('../middlewares/auth.middleware');
 const roleMiddleware = require('../middlewares/role.middleware');
 
@@ -8,27 +8,55 @@ router.use(auth);
 
 router.get('/', async (req, res) => {
   try {
-    const plantillas = await Plantilla.findAll();
+    const { rol, id } = req.usuario;
+    let where = {};
+
+    if (rol === 'sistema') {
+      // no additional filters
+    } else {
+      const gestiones = await UsuarioGestion.findAll({ where: { usuarioId: id } });
+      const gestionIds = gestiones.map(g => g.gestionId);
+      if (!gestionIds.length) return res.json([]);
+      where.gestionId = gestionIds;
+      if (rol === 'agente') {
+        where.visible = true;
+      }
+    }
+
+    const plantillas = await Plantilla.findAll({ where });
     res.json(plantillas);
   } catch (err) {
     res.status(500).json({ mensaje: 'Error al obtener plantillas' });
   }
 });
 
-router.post('/', roleMiddleware('sistema'), async (req, res) => {
+router.post('/', roleMiddleware('sistema', 'supervisor'), async (req, res) => {
   try {
-    const { texto } = req.body;
-    const nueva = await Plantilla.create({ texto, visible: true });
+    const { texto, gestionId } = req.body;
+    if (!gestionId) return res.status(400).json({ mensaje: 'gestionId requerido' });
+
+    if (req.usuario.rol === 'supervisor') {
+      const relacion = await UsuarioGestion.findOne({ where: { usuarioId: req.usuario.id, gestionId } });
+      if (!relacion) return res.status(403).json({ mensaje: 'No pertenece a la gestión' });
+    }
+
+    const nueva = await Plantilla.create({ texto, gestionId, visible: true });
     res.status(201).json(nueva);
   } catch (err) {
     res.status(500).json({ mensaje: 'Error al crear plantilla' });
   }
 });
 
-router.put('/:id/visible', roleMiddleware('sistema'), async (req, res) => {
+router.put('/:id/visible', roleMiddleware('sistema', 'supervisor'), async (req, res) => {
   try {
     const plantilla = await Plantilla.findByPk(req.params.id);
     if (!plantilla) return res.status(404).json({ mensaje: 'No encontrada' });
+
+    if (req.usuario.rol === 'supervisor') {
+      const relacion = await UsuarioGestion.findOne({ where: { usuarioId: req.usuario.id, gestionId: plantilla.gestionId } });
+      if (!relacion) return res.status(403).json({ mensaje: 'No autorizado' });
+    }
+
     plantilla.visible = req.body.visible;
     await plantilla.save();
     res.json(plantilla);


### PR DESCRIPTION
## Summary
- reference `Gestion` from `Plantilla` with `gestionId`
- expose new relations between `Gestion` and `Plantilla`
- restrict plantilla creation and visibility based on user gestiones

## Testing
- `npm --prefix backend test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6860cfc61c288327b903192c1f69b9bf