### PR TITLE
Implement supervisor user management checks

### DIFF
--- a/backend/routes/usuario.routes.js
+++ b/backend/routes/usuario.routes.js
@@ -9,9 +9,9 @@ const roleMiddleware = require('../middlewares/role.middleware');
 router.use(authMiddleware);
 
 // Rutas
-router.get('/', usuarioController.listarUsuarios);
-router.post('/', roleMiddleware('sistema'), usuarioController.crearUsuario);
-router.put('/:id', roleMiddleware('sistema'), usuarioController.actualizarUsuario);
+router.get('/', roleMiddleware('sistema', 'supervisor'), usuarioController.listarUsuarios);
+router.post('/', roleMiddleware('sistema', 'supervisor'), usuarioController.crearUsuario);
+router.put('/:id', roleMiddleware('sistema', 'supervisor'), usuarioController.actualizarUsuario);
 router.patch('/:id/estado', roleMiddleware('sistema'), usuarioController.cambiarEstadoUsuario);
 
 


### PR DESCRIPTION
## Summary
- allow supervisors to access user routes
- restrict supervisors to creating/updating only `agente` users
- ensure supervisors only assign gestiones they handle
- show supervisors only users tied to their gestiones

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6860d1a815b08327a96c76582b79d6b6