### PR TITLE
Load gestiones on login

### DIFF
--- a/backend/controllers/auth.controller.js
+++ b/backend/controllers/auth.controller.js
@@ -1,4 +1,5 @@
 const Usuario = require('../models/usuario.model');
+const { Gestion } = require('../models');
 const { hashPassword, comparePasswords } = require('../utils/hash');
 const { generateToken } = require('../utils/jwt');
 
@@ -55,16 +56,15 @@ exports.login = async (req, res) => {
       apellido: user.apellido
     });
 
+    const fullUser = await Usuario.findByPk(user.id, {
+      include: [{ model: Gestion }]
+    });
+    const { password_hash, ...userData } = fullUser.toJSON();
+
     res.json({
       message: 'Login exitoso',
       token,
-      user: {
-        id: user.id,
-        username: user.username,
-        rol: user.rol,
-        nombre: user.nombre,
-        apellido: user.apellido
-      }
+      user: userData
     });
   } catch (err) {
     console.error('🔥 Error en login:', err);

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -22,7 +22,9 @@ const Dashboard = () => {
   const usuario = JSON.parse(localStorage.getItem('usuario') || '{}');
   const esSistema = usuario.rol === 'sistema';
   const esSupervisor = usuario.rol === 'supervisor';
-  const [usuarioGestionIds, setUsuarioGestionIds] = useState([]);
+  const [usuarioGestionIds, setUsuarioGestionIds] = useState(
+    usuario.Gestions ? usuario.Gestions.map(g => g.id) : []
+  );
   const [gestionPlantillaId, setGestionPlantillaId] = useState('');
 
   const cargarUsuarios = async () => {
@@ -31,12 +33,6 @@ const Dashboard = () => {
         headers: { Authorization: `Bearer ${token}` }
       });
       setUsuarios(res.data);
-      if (esSupervisor) {
-        const yo = res.data.find(u => u.id === usuario.id);
-        if (yo && yo.Gestions) {
-          setUsuarioGestionIds(yo.Gestions.map(g => g.id));
-        }
-      }
     } catch (err) {
       console.error('Error al cargar usuarios:', err);
       setError('Error al cargar usuarios');

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -11,8 +11,9 @@ export default function Login() {
     e.preventDefault();
     try {
       const res = await axios.post('/auth/login', { username, password });
-      localStorage.setItem('token', res.data.token);
-      localStorage.setItem('usuario', JSON.stringify(res.data.user));
+      const { token, user } = res.data;
+      localStorage.setItem('token', token);
+      localStorage.setItem('usuario', JSON.stringify(user));
       navigate('/dashboard');
     } catch (err) {
       alert('Credenciales incorrectas');


### PR DESCRIPTION
## Summary
- include `Gestion` relations during login
- store complete user object after login
- use stored gestiones to filter supervisor options

## Testing
- `npm test` (fails: Missing script)
- `npm test` in frontend (fails: Missing script)

------
https://chatgpt.com/codex/tasks/task_e_6860d2f3f37c83278fa24fb61c1de45a