### PR TITLE
Remove defaults from models; set via routes

### DIFF
--- a/backend/controllers/auth.controller.js
+++ b/backend/controllers/auth.controller.js
@@ -18,7 +18,8 @@ exports.register = async (req, res) => {
       password_hash,
       rol,
       nombre,
-      apellido
+      apellido,
+      estado: 'activo'
     });
 
     res.status(201).json({

--- a/backend/crearAdmin.js
+++ b/backend/crearAdmin.js
@@ -13,7 +13,8 @@ const { hashPassword } = require('./utils/hash');
       password_hash,
       rol: 'sistema',
       nombre: 'Admin',
-      apellido: 'Principal'
+      apellido: 'Principal',
+      estado: 'activo'
     });
 
     console.log('✅ Usuario admin creado:', admin.username);

--- a/backend/models/plantilla.model.js
+++ b/backend/models/plantilla.model.js
@@ -16,7 +16,7 @@ const Plantilla = sequelize.define('Plantilla', {
   },
   visible: {
     type: DataTypes.BOOLEAN,
-    defaultValue: true
+    // default removed; routes must set value explicitly
   }
 }, {
   tableName: 'Plantillas'

--- a/backend/models/usuario.model.js
+++ b/backend/models/usuario.model.js
@@ -32,7 +32,6 @@ const Usuario = sequelize.define('Usuario', {
   },
   estado: {
     type: DataTypes.STRING,
-    //defaultValue: 'activo',
     allowNull: false
   },
   createdAt: {


### PR DESCRIPTION
## Summary
- remove `defaultValue` from plantilla's `visible` field
- remove `defaultValue` from usuario's `estado` field
- explicitly set `estado` when users are created
- explicitly set `estado` for seed admin user

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6860d5b686e48327920c4167f679e994