### PR TITLE
Fix axios base paths

### DIFF
--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import axios from '../api/axios';
+import api from '../api/axios';
 import Select from 'react-select';
 import makeAnimated from 'react-select/animated';
 
@@ -29,7 +29,7 @@ const Dashboard = () => {
 
   const cargarUsuarios = async () => {
     try {
-      const res = await axios.get('/usuarios', {
+      const res = await api.get('/usuarios', {
         headers: { Authorization: `Bearer ${token}` }
       });
       setUsuarios(res.data);
@@ -41,7 +41,7 @@ const Dashboard = () => {
 
   const cargarGestiones = async () => {
     try {
-      const res = await axios.get('/gestiones', {
+      const res = await api.get('/gestiones', {
         headers: { Authorization: `Bearer ${token}` }
       });
       setGestiones(res.data.map(g => ({ value: g.id, label: g.nombre })));
@@ -53,7 +53,7 @@ const Dashboard = () => {
 
   const cargarPlantillas = async () => {
     try {
-      const res = await axios.get('/plantillas', {
+      const res = await api.get('/plantillas', {
         headers: { Authorization: `Bearer ${token}` }
       });
       setPlantillas(res.data);
@@ -64,7 +64,7 @@ const Dashboard = () => {
 
   const crearUsuario = async () => {
     try {
-      await axios.post('/usuarios', {
+      await api.post('/usuarios', {
         ...formUsuario,
         gestiones: gestionesSeleccionadas.map(g => g.value)
       }, { headers: { Authorization: `Bearer ${token}` } });
@@ -79,7 +79,7 @@ const Dashboard = () => {
 
   const agregarGestion = async () => {
     try {
-      await axios.post('/gestiones', { nombre: nuevaGestion }, { headers: { Authorization: `Bearer ${token}` } });
+      await api.post('/gestiones', { nombre: nuevaGestion }, { headers: { Authorization: `Bearer ${token}` } });
       setNuevaGestion('');
       cargarGestiones();
     } catch (err) {
@@ -89,7 +89,7 @@ const Dashboard = () => {
 
   const agregarPlantilla = async () => {
     try {
-      await axios.post('/plantillas', { texto: nuevaPlantilla, gestionId: gestionPlantillaId }, { headers: { Authorization: `Bearer ${token}` } });
+      await api.post('/plantillas', { texto: nuevaPlantilla, gestionId: gestionPlantillaId }, { headers: { Authorization: `Bearer ${token}` } });
       setNuevaPlantilla('');
       setGestionPlantillaId('');
       cargarPlantillas();
@@ -100,7 +100,7 @@ const Dashboard = () => {
 
   const cambiarVisibilidad = async (id, visible) => {
     try {
-      await axios.put(`/plantillas/${id}/visible`, { visible }, { headers: { Authorization: `Bearer ${token}` } });
+      await api.put(`/plantillas/${id}/visible`, { visible }, { headers: { Authorization: `Bearer ${token}` } });
       cargarPlantillas();
     } catch (err) {
       console.error('Error al actualizar plantilla:', err);
@@ -109,7 +109,7 @@ const Dashboard = () => {
 
   const cambiarEstado = async (id) => {
     try {
-      await axios.patch(`/usuarios/${id}/estado`, {}, {
+      await api.patch(`/usuarios/${id}/estado`, {}, {
         headers: { Authorization: `Bearer ${token}` }
       });
       cargarUsuarios();

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import axios from '../api/axios';
+import api from '../api/axios';
 import { useNavigate } from 'react-router-dom';
 
 export default function Login() {
@@ -10,7 +10,7 @@ export default function Login() {
   const handleLogin = async (e) => {
     e.preventDefault();
     try {
-      const res = await axios.post('/auth/login', { username, password });
+      const res = await api.post('/auth/login', { username, password });
       const { token, user } = res.data;
       localStorage.setItem('token', token);
       localStorage.setItem('usuario', JSON.stringify(user));


### PR DESCRIPTION
## Summary
- import shared axios instance as `api`
- clean API calls in Login and Dashboard to use base `/api` URL

## Testing
- `npm run build` *(fails: vite Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6860d6a1cca88327bb04f4a84e663385