### PR TITLE
Update Tailwind integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# RespuestApp
+
+This project uses **Vite** with **React** and **Tailwind CSS**.
+
+## Tailwind setup
+
+Tailwind is integrated using the `@tailwindcss/vite` plugin and PostCSS.
+The Tailwind directives are placed in `frontend/src/index.css` and compiled
+through Vite:
+
+```css
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+The configuration files used by Vite and Tailwind are:
+
+- `frontend/vite.config.js` – Vite configuration which loads React and the Tailwind plugin.
+  ```js
+  plugins: [react(), tailwindcss()]
+  ```
+- `frontend/postcss.config.js` – defines the PostCSS plugins so Tailwind can process the CSS.
+- `frontend/tailwind.config.js` – Tailwind settings and content paths.
+
+Run the development server from the `frontend` directory:
+
+```bash
+npm run dev
+```
+
+Vite will build the Tailwind styles automatically.

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
   plugins: {
-    "@tailwindcss/postcss": {},
+    tailwindcss: {},
     autoprefixer: {},
   },
 };

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,1 +1,10 @@
-@import 'tailwindcss';
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  font-family: sans-serif;
+  margin: 0;
+  padding: 0;
+  background-color: #f3f4f6;
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,8 +1,9 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
+
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), tailwindcss()],
   server: {
     port: 5173,
     proxy: {


### PR DESCRIPTION
## Summary
- ensure Tailwind plugin is used in Vite
- update PostCSS config and restore base styles
- document setup in README

## Testing
- `node node_modules/vite/bin/vite.js build` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*


------
https://chatgpt.com/codex/tasks/task_e_6860e3626edc8327ae5dae0db2f5d759