### PR TITLE
Add Node ESM flag

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,7 @@
 {
     "name": "respuestapp-frontend",
     "version": "1.0.0",
+    "type": "module",
     "private": true,
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
## Summary
- enable ES modules in `frontend/package.json`

## Testing
- `npm run dev` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_6860e6cd75688327942391b8125fbb8a