### PR TITLE
Add Node ESM flag

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,7 @@
 {
     "name": "respuestapp-frontend",
     "version": "1.0.0",
+    "type": "module",
     "private": true,
     "scripts": {
         "dev": "vite",

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {},
   },
 };


### PR DESCRIPTION
## Summary
- enable ES modules in `frontend/package.json`
- update PostCSS config for Tailwind plugin

## Testing
- `npm run dev` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*


------
https://chatgpt.com/codex/tasks/task_e_6860e6cd75688327942391b8125fbb8a